### PR TITLE
Downgrade the use of flat_map to map.flatten instead

### DIFF
--- a/lib/stash/client.rb
+++ b/lib/stash/client.rb
@@ -29,10 +29,10 @@ module Stash
     end
 
     def repositories
-      projects.flat_map do |project|
+      projects.map do |project|
         relative_project_path = project.fetch('link').fetch('url') + '/repos'
         fetch_all @url.join(remove_leading_slash(relative_project_path))
-      end
+      end.flatten
     end
 
     def project_named(name)


### PR DESCRIPTION
flat_map requires 1.9.3. However, Centos 6.5 (the latest version of Centos) only ships with 1.8.7. This is the only change necessary for stash-client to work on 1.8.7.
